### PR TITLE
fix: default Buyer selection in SignupForm

### DIFF
--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,3 +1,4 @@
+// src/components/SignupForm.tsx
 'use client';
 
 import React, { useState, FormEvent } from 'react';
@@ -5,7 +6,8 @@ import React, { useState, FormEvent } from 'react';
 export default function SignupForm() {
     const [email, setEmail] = useState('');
     const [name, setName] = useState('');
-    const [role, setRole] = useState<'buyer' | 'builder' | ''>('');
+    // Default to 'buyer' so Builder never appears selected by default
+    const [role, setRole] = useState<'buyer' | 'builder'>('buyer');
     const [message, setMessage] = useState('');
     const [submitting, setSubmitting] = useState(false);
 


### PR DESCRIPTION
Ensures the Buyer radio is pre-selected by default so Builder never appears selected on page load.