### PR TITLE
feat: add Plausible + GTM integration and static export config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+// next.config.js
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",
     "build": "next build",
+    "export": "next export",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,23 +1,39 @@
 // src/pages/_app.tsx
+
+// Import global styles and types for your Next.js app
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+
+// Import the <Head> component to manually inject scripts into the HTML <head>
+import Head from "next/head";
+
+// Import Next.js's <Script> component (used for GTM only in this setup)
 import Script from "next/script";
+
+// Import your custom attribution hook to capture traffic sources (e.g. utm_source)
 import { useChannelAttribution } from "@/hooks/useChannelAttribution";
 
 export default function App({ Component, pageProps }: AppProps) {
-  // Capture the channel/source on first visit
+  // This hook sets or updates `br_src` in localStorage based on UTM parameters
   useChannelAttribution();
 
   return (
     <>
-      {/* Plausible Analytics */}
-      <Script
-        strategy="afterInteractive"
-        src={`https://plausible.io/js/plausible.js`}
-        data-domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
-      />
+      {/*Plausible Analytics Script
+          We're using <Head> instead of <Script> because the site uses static export (`next export`).
+          <Script> can fail to inject properly in statically exported HTML.
+      */}
+      <Head>
+        <script
+          defer
+          data-domain="brassroots.market" // Hardcoded domain ensures tracking works even if env vars are missing
+          src="https://plausible.io/js/plausible.js"
+        ></script>
+      </Head>
 
-      {/* Google Tag Manager */}
+      {/*Google Tag Manager (GTM) Script
+          This uses the Next.js <Script> component because GTM relies on runtime execution.
+      */}
       <Script id="gtm" strategy="afterInteractive">
         {`
           (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -28,6 +44,9 @@ export default function App({ Component, pageProps }: AppProps) {
         `}
       </Script>
 
+      {/*Main App Component
+          This renders your actual pages (e.g. the landing page and signup form)
+      */}
       <Component {...pageProps} />
     </>
   );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,26 @@
-import { Html, Head, Main, NextScript } from "next/document";
+// src/pages/_document.tsx
 
-export default function Document() {
-  return (
-    <Html lang="en">
-      <Head />
-      <body className="antialiased">
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          {/* ✅ Plausible Analytics for Static Export */}
+          <script
+            defer
+            data-domain="brassroots.market"
+            src="https://plausible.io/js/plausible.js"
+          ></script>
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }
+
+export default MyDocument;


### PR DESCRIPTION
Implements tracking for pageviews and signups via Plausible, injects source attribution, and prepares dashboard visibility for pilot stakeholders.