### PR TITLE
feat: capture utm fields in signup flow

### DIFF
--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -4,15 +4,14 @@
 import React, { useState, FormEvent } from 'react';
 
 declare global {
-  interface Window {
-    plausible?: (eventName: string) => void;
-  }
+    interface Window {
+        plausible?: (eventName: string) => void;
+    }
 }
 
 export default function SignupForm() {
     const [email, setEmail] = useState('');
     const [name, setName] = useState('');
-    // Default to 'buyer' so Seller never appears selected by default
     const [role, setRole] = useState<'buyer' | 'seller'>('buyer');
     const [message, setMessage] = useState('');
     const [submitting, setSubmitting] = useState(false);
@@ -30,16 +29,23 @@ export default function SignupForm() {
                     email,
                     name,
                     role,
-                    channel_source: localStorage.getItem('br_src') || null,
+                    // ✅ Send UTM fields as a nested "fields" object
+                    fields: {
+                        utm_source: localStorage.getItem('utm_source') || 'direct',
+                        utm_medium: localStorage.getItem('utm_medium') || 'unknown',
+                        utm_campaign: localStorage.getItem('utm_campaign') || 'unknown',
+                        br_src: localStorage.getItem('br_src') || 'direct',
+                    },
                 }),
             });
 
             const result = await res.json();
+
             if (!res.ok) {
                 throw new Error(result?.error?.message || 'Signup failed');
             }
 
-            // Fire Plausible goal event
+            // ✅ Fire Plausible event for analytics tracking
             if (typeof window !== 'undefined' && window.plausible) {
                 window.plausible('signup');
             }
@@ -55,6 +61,7 @@ export default function SignupForm() {
 
     return (
         <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
+            {/* Email Field */}
             <div>
                 <label htmlFor="email" className="block text-sm font-medium">
                     Email
@@ -70,6 +77,7 @@ export default function SignupForm() {
                 />
             </div>
 
+            {/* Name Field */}
             <div>
                 <label htmlFor="name" className="block text-sm font-medium">
                     Name or Nick
@@ -85,6 +93,7 @@ export default function SignupForm() {
                 />
             </div>
 
+            {/* Role Selection */}
             <fieldset className="flex items-center space-x-4">
                 <legend className="sr-only">Role</legend>
                 <label className="flex items-center space-x-2">
@@ -112,6 +121,7 @@ export default function SignupForm() {
                 </label>
             </fieldset>
 
+            {/* Submit Button */}
             <button
                 type="submit"
                 disabled={submitting}
@@ -124,16 +134,26 @@ export default function SignupForm() {
                         : 'Joined!'}
             </button>
 
+            {/* Success / Error Message */}
             {message && (
                 <p
-                    className={`mt - 2 text - center ${
-    message.toLowerCase().includes('thank')
-        ? 'text-green-600'
-        : 'text-red-600'
-} `}
+                    className={`mt-2 text-center ${message.toLowerCase().includes('thank')
+                            ? 'text-green-600'
+                            : 'text-red-600'
+                        }`}
                 >
                     {message}
                 </p>
+            )}
+
+            {/* Optional Debug Output in Dev */}
+            {process.env.NODE_ENV !== 'production' && (
+                <pre className="mt-4 text-xs text-gray-500">
+                    utm_source: {localStorage.getItem('utm_source')}{'\n'}
+                    utm_medium: {localStorage.getItem('utm_medium')}{'\n'}
+                    utm_campaign: {localStorage.getItem('utm_campaign')}{'\n'}
+                    br_src: {localStorage.getItem('br_src')}
+                </pre>
             )}
         </form>
     );

--- a/src/pages/api/signup.ts
+++ b/src/pages/api/signup.ts
@@ -7,13 +7,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(405).json({ error: { message: 'Method not allowed' } });
     }
 
-    const { email, name, role, channel_source } = req.body;
+    // Destructure body payload
+    const { email, name, role, fields } = req.body;
 
+    // Ensure required fields exist
     if (!email || !name || !role) {
         return res.status(400).json({ error: { message: 'Missing required fields' } });
     }
 
-    // 🧪 Return fake success if in test mode
+    // Safely extract optional UTM fields
+    const utm_source = fields?.utm_source || null;
+    const utm_medium = fields?.utm_medium || null;
+    const utm_campaign = fields?.utm_campaign || null;
+
+    // Return mocked success in test mode (for CI or E2E)
     if (process.env.NODE_ENV === 'test') {
         return res.status(200).json({ message: 'Mocked success in test mode' });
     }
@@ -22,28 +29,30 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const apiKey = process.env.MAILERLITE_API_KEY;
         const listId = process.env.MAILERLITE_LIST_ID;
 
-        if (!apiKey) {
-            throw new Error('Missing MAILERLITE_API_KEY');
-        }
-        if (!listId) {
-            throw new Error('Missing MAILERLITE_LIST_ID');
-        }
+        if (!apiKey) throw new Error('Missing MAILERLITE_API_KEY');
+        if (!listId) throw new Error('Missing MAILERLITE_LIST_ID');
 
+        // Construct payload for MailerLite
+        const payload = {
+            email,
+            name,
+            fields: {
+                role,
+                utm_source,     // e.g., "reddit"
+                utm_medium,     // e.g., "cpc"
+                utm_campaign    // e.g., "pilot_launch"
+            },
+            groups: [listId]
+        };
+
+        // Send subscriber to MailerLite
         const response = await fetch('https://connect.mailerlite.com/api/subscribers', {
             method: 'POST',
             headers: {
                 Authorization: `Bearer ${apiKey}`,
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify({
-                email,
-                name,
-                fields: {
-                    role,
-                    channel_source,
-                },
-                groups: [listId],
-            }),
+            body: JSON.stringify(payload)
         });
 
         if (!response.ok) {
@@ -56,6 +65,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (err instanceof Error) {
             return res.status(500).json({ error: { message: err.message } });
         }
-        return res.status(500).json({ error: { message: 'Unknown error' } });
+        return res.status(500).json({ error: { message: 'Unknown error occurred' } });
     }
 }


### PR DESCRIPTION
This PR adds support for capturing utm_source, utm_medium, and utm_campaign and sending them to MailerLite via the signup API.